### PR TITLE
Added 'forwardOnly' param, 'seed' can be an array of seed points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # streamlines
 
+This is a fork of https://github.com/anvaka/streamlines - a brilliant library based on [this paper](http://web.cs.ucdavis.edu/~ma/SIGGRAPH02/course23/notes/papers/Jobard.pdf). This fork added two things:
+
+* `seed` param can be an array, and all points for the array will be used (if valid) before selecting random points.
+* `forwardOnly` param is added, and if set to `true` line will be drawn only in one direction from the seed (current implementation goes back to seed point and draws in the other direction as well).
+
+----
+
 The library builds streamlines for arbitrary vector fields, trying to keep uniform distance
 between them.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # streamlines
 
-This is a fork of https://github.com/anvaka/streamlines - a brilliant library based on [this paper](http://web.cs.ucdavis.edu/~ma/SIGGRAPH02/course23/notes/papers/Jobard.pdf). This fork added two things:
-
-* `seed` param can be an array, and all points for the array will be used (if valid) before selecting random points.
-* `forwardOnly` param is added, and if set to `true` line will be drawn only in one direction from the seed (current implementation goes back to seed point and draws in the other direction as well).
-
-----
-
 The library builds streamlines for arbitrary vector fields, trying to keep uniform distance
 between them.
 
@@ -71,6 +64,8 @@ streamlines({
 
   // Defines the first point where integration should start. If this is
   // not specified a random point inside boundingBox is selected
+  // You can pass array of seed points, they are going to be used one by one
+  // if they satisfy the rules.
   seed: {x: -1, y: 1},
 
   // Separation distance between new streamlines.
@@ -80,7 +75,11 @@ streamlines({
   dTest: 0.25,
 
   // Integration time step (passed to RK4 method.)
-  timeStep: 0.01
+  timeStep: 0.01,
+
+  // If set to true, lines are going to be drawn from the seed points
+  // only in the direction of the vector field
+  forwardOnly: false
 }).run();
 ```
 

--- a/index.js
+++ b/index.js
@@ -32,12 +32,17 @@ function computeStreamlines(protoOptions) {
   options.vectorField = protoOptions.vectorField;
   options.onStreamlineAdded = protoOptions.onStreamlineAdded;
   options.onPointAdded = protoOptions.onPointAdded;
+  options.forwardOnly = protoOptions.forwardOnly;
 
   if (!protoOptions.seed) {
     options.seed = new Vector(
       Math.random() * boundingBox.width + boundingBox.left,
       Math.random() * boundingBox.height + boundingBox.top
     );
+  } else if (Array.isArray(protoOptions.seed)) {
+    var seed = protoOptions.seed.shift();
+    options.seed = new Vector(seed.x, seed.y);
+    options.seedArray = protoOptions.seed;
   } else {
     options.seed = new Vector(protoOptions.seed.x, protoOptions.seed.y);
   }

--- a/lib/streamLineIntegrator.js
+++ b/lib/streamLineIntegrator.js
@@ -41,6 +41,14 @@ function createStreamlineIntegrator(start, grid, config) {
       var cx = p.x - v.y * config.dSep;
       var cy = p.y + v.x * config.dSep;
 
+      // console.log(config)
+      if (Array.isArray(config.seedArray) && config.seedArray.length > 0) {
+        var seed = config.seedArray.shift();
+        cx = seed.x;
+        cy = seed.y;
+        console.log(cx, cy)
+      }
+
       if (!grid.isOutside(cx, cy) && !grid.isTaken(cx, cy, checkDSep)) {
         // this will let us check the other side. When we get back
         // into this method, the point `cx, cy` will be taken (by construction of another streamline)
@@ -80,8 +88,12 @@ function createStreamlineIntegrator(start, grid, config) {
           if (shouldPause) return;
         } else {
           // Reset position to start, and grow backwards:
-          pos = start;
-          state = BACKWARD;
+          if (config.forwardOnly)  {
+            state = DONE;
+          } else {
+            pos = start;
+            state = BACKWARD;
+          }
         }
       } 
       if (state === BACKWARD) {

--- a/lib/streamLineIntegrator.js
+++ b/lib/streamLineIntegrator.js
@@ -41,12 +41,10 @@ function createStreamlineIntegrator(start, grid, config) {
       var cx = p.x - v.y * config.dSep;
       var cy = p.y + v.x * config.dSep;
 
-      // console.log(config)
       if (Array.isArray(config.seedArray) && config.seedArray.length > 0) {
         var seed = config.seedArray.shift();
         cx = seed.x;
         cy = seed.y;
-        console.log(cx, cy)
       }
 
       if (!grid.isOutside(cx, cy) && !grid.isTaken(cx, cy, checkDSep)) {


### PR DESCRIPTION
Hey, for my own use, I added `forwardOnly` param and enabled that `seed` param accepts array of seed points. This was super useful to me while I was working on generative art pieces. If you thing it makes sense for it to be the part of the library, let me know and I'll clean up the PR and add documentation.

Maybe `forwardOnly` should be renamed to `direction` and accept enum values (`FORWARD`, `BACK` and `BOTH`).

Once again, thank you for the awesome work!

Cheers!

P.S. I totally understand if you feel like this shouldn't be the part of the library.